### PR TITLE
refactor: use Buffer for cache key encoding

### DIFF
--- a/__tests__/lib/api-cache.test.js
+++ b/__tests__/lib/api-cache.test.js
@@ -84,10 +84,16 @@ describe('RequestCache', () => {
     
     const key1 = cache.generateKey(endpoint, options);
     const key2 = cache.generateKey(endpoint, options);
-    
+
     expect(key1).toBe(key2);
     expect(typeof key1).toBe('string');
     expect(key1.length).toBeGreaterThan(0);
+
+    const parsed = JSON.parse(Buffer.from(key1, 'base64').toString('utf8'));
+    expect(parsed).toMatchObject({
+      endpoint,
+      method: 'GET'
+    });
   });
 
   test('should store and retrieve data correctly', () => {

--- a/__tests__/lib/request-deduplication.test.js
+++ b/__tests__/lib/request-deduplication.test.js
@@ -123,10 +123,16 @@ describe('RequestDeduplicationService', () => {
     
     const key1 = service.generateKey(url, options);
     const key2 = service.generateKey(url, options);
-    
+
     expect(key1).toBe(key2);
     expect(typeof key1).toBe('string');
     expect(key1.length).toBeGreaterThan(0);
+
+    const parsed = JSON.parse(Buffer.from(key1, 'base64').toString('utf8'));
+    expect(parsed).toMatchObject({
+      url,
+      method: 'GET'
+    });
   });
 
   test('should deduplicate identical requests', async () => {

--- a/lib/api-cache.js
+++ b/lib/api-cache.js
@@ -60,8 +60,7 @@ class RequestCache {
       params: JSON.stringify(params),
       body: typeof body === 'string' ? body : JSON.stringify(body)
     };
-    
-    return btoa(JSON.stringify(keyData)).replace(/[+/=]/g, '');
+    return Buffer.from(JSON.stringify(keyData)).toString('base64');
   }
 
   /**
@@ -155,7 +154,7 @@ class RequestCache {
     const pattern = new RegExp(endpoint.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
     this.invalidate((key) => {
       try {
-        const keyData = JSON.parse(atob(key));
+        const keyData = JSON.parse(Buffer.from(key, 'base64').toString('utf8'));
         return pattern.test(keyData.endpoint);
       } catch {
         return false;
@@ -169,7 +168,7 @@ class RequestCache {
   invalidateByMethod(method) {
     this.invalidate((key) => {
       try {
-        const keyData = JSON.parse(atob(key));
+        const keyData = JSON.parse(Buffer.from(key, 'base64').toString('utf8'));
         return keyData.method === method;
       } catch {
         return false;
@@ -307,7 +306,7 @@ export const CacheInvalidationStrategies = {
   onPromptUpdate: (cache, promptId) => {
     cache.invalidate((key) => {
       try {
-        const keyData = JSON.parse(atob(key));
+        const keyData = JSON.parse(Buffer.from(key, 'base64').toString('utf8'));
         return keyData.endpoint === `/api/prompts/${promptId}` || keyData.endpoint === '/api/prompts';
       } catch {
         return false;

--- a/lib/request-deduplication.js
+++ b/lib/request-deduplication.js
@@ -89,8 +89,7 @@ class RequestDeduplicationService {
       headers,
       body: typeof body === 'string' ? body : JSON.stringify(body)
     };
-    
-    return btoa(JSON.stringify(keyData)).replace(/[+/=]/g, '');
+    return Buffer.from(JSON.stringify(keyData)).toString('base64');
   }
 
   /**


### PR DESCRIPTION
## Summary
- replace deprecated btoa/atob usage with Buffer-based base64 encoding in request cache and request deduplication modules
- ensure cache key generation and parsing are symmetric
- adjust unit tests to decode keys using Buffer

## Testing
- `npm test` *(fails: TypeError: Cannot set property url of #<NextRequest> which has only a getter, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a15c1959fc832a97ca5dd1ad1b7d82