### PR TITLE
docs: rename repository references to promptMinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@
 1. **克隆项目**
 
 ```bash
-git clone https://github.com/your-username/prompt-manage.git
-cd prompt-manage
+git clone https://github.com/your-username/promptMinder.git
+cd promptMinder
 ```
 
 2. **安装依赖**
@@ -256,7 +256,7 @@ CREATE TABLE prompt_contributions (
 ### 项目结构
 
 ```
-prompt-manage/
+promptMinder/
 ├── app/                    # Next.js App Router
 │   ├── api/               # API 路由
 │   ├── prompts/           # 提示词相关页面
@@ -301,9 +301,9 @@ prompt-manage/
 
 ### 技术支持
 
-- 📖 查看 [文档](https://github.com/your-username/prompt-manage/wiki)
-- 🐛 报告 [问题](https://github.com/your-username/prompt-manage/issues)
-- 💬 加入 [讨论](https://github.com/your-username/prompt-manage/discussions)
+- 📖 查看 [文档](https://github.com/your-username/promptMinder/wiki)
+- 🐛 报告 [问题](https://github.com/your-username/promptMinder/issues)
+- 💬 加入 [讨论](https://github.com/your-username/promptMinder/discussions)
 
 ## 📄 许可证
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -51,8 +51,8 @@ A professional prompt management platform that makes AI prompt management simple
 1. **Clone the project**
 
 ```bash
-git clone https://github.com/your-username/prompt-manage.git
-cd prompt-manage
+git clone https://github.com/your-username/promptMinder.git
+cd promptMinder
 ```
 
 2. **Install dependencies**
@@ -256,7 +256,7 @@ Language files are located in the `/messages` directory:
 ### Project Structure
 
 ```
-prompt-manage/
+promptMinder/
 ├── app/                    # Next.js App Router
 │   ├── api/               # API routes
 │   ├── prompts/           # Prompt-related pages
@@ -301,9 +301,9 @@ Use [Canny](https://canny.io) to collect user feedback and feature requests.
 
 ### Technical Support
 
-- 📖 View [Documentation](https://github.com/your-username/prompt-manage/wiki)
-- 🐛 Report [Issues](https://github.com/your-username/prompt-manage/issues)
-- 💬 Join [Discussions](https://github.com/your-username/prompt-manage/discussions)
+- 📖 View [Documentation](https://github.com/your-username/promptMinder/wiki)
+- 🐛 Report [Issues](https://github.com/your-username/promptMinder/issues)
+- 💬 Join [Discussions](https://github.com/your-username/promptMinder/discussions)
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary
- update repository name to `promptMinder` in README files

## Testing
- `npm test` *(fails: 9 failed, 12 passed, 21 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a15c0fdc98832a882773ff73527147