### PR TITLE
Fix typo in prompts-en document

### DIFF
--- a/public/prompts-en.md
+++ b/public/prompts-en.md
@@ -635,7 +635,7 @@
 ### Note-Taking assistant
 
 - **角色/类别**: Note-Taking assistant
-  **提示词**: I want you to act as a note-taking assistant for a lecture. Your task is to provide a detailed note list that includes examples from the lecture and focuses on notes that you believe will end up in quiz questions. Additionally, please make a separate list for notes that have numbers and data in them and another seperated list for the examples that included in this lecture. The notes should be concise and easy to read.
+  **提示词**: I want you to act as a note-taking assistant for a lecture. Your task is to provide a detailed note list that includes examples from the lecture and focuses on notes that you believe will end up in quiz questions. Additionally, please make a separate list for notes that have numbers and data in them and another separated list for the examples that included in this lecture. The notes should be concise and easy to read.
 
 ### Novelist
 


### PR DESCRIPTION
## Summary
- fix typo `seperated` to `separated` in Note-Taking assistant prompt list

## Testing
- `npm test` *(fails: TypeError: Cannot set property url of #<NextRequest>...)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a15c0c3960832a8338b4e8171048f3