### PR TITLE
feat: add new version shortcut

### DIFF
--- a/app/prompts/page.js
+++ b/app/prompts/page.js
@@ -334,6 +334,13 @@ export default function PromptsPage() {
     setSelectedVersions(versions);
   }, []);
 
+  const handleCreateNewVersion = useCallback(() => {
+    if (selectedVersions?.length) {
+      const latest = selectedVersions[0];
+      window.location.href = `/prompts/${latest.id}/edit`;
+    }
+  }, [selectedVersions]);
+
   const handleCreatePrompt = useCallback(async () => {
     if (!t?.promptsPage) return;
     
@@ -710,10 +717,13 @@ export default function PromptsPage() {
           <VisuallyHidden.Root>
             <DialogTitle>Dialog</DialogTitle>
           </VisuallyHidden.Root>
-          <DialogHeader>
+          <DialogHeader className="flex items-center justify-between">
             <DialogTitle className="text-xl">
               {tp.versionHistoryTitle}
             </DialogTitle>
+            <Button size="sm" onClick={handleCreateNewVersion}>
+              {tp.createNewVersion}
+            </Button>
           </DialogHeader>
           <div className="space-y-3 mt-4 max-h-[60vh] overflow-y-auto pr-1">
             {selectedVersions?.map((version) => (

--- a/messages/en.json
+++ b/messages/en.json
@@ -337,6 +337,7 @@
     "manageTags": "Manage Tags",
     "versionsCount": "{count} versions",
     "versionHistoryTitle": "Version History",
+    "createNewVersion": "Create New Version",
     "deleteConfirmTitle": "Confirm Deletion",
     "deleteConfirmDescription": "Are you sure you want to delete this prompt? This action cannot be undone.",
     "cancel": "Cancel",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -337,6 +337,7 @@
     "manageTags": "标签管理",
     "versionsCount": "{count} 个版本",
     "versionHistoryTitle": "版本历史",
+    "createNewVersion": "创建新版本",
     "deleteConfirmTitle": "确认删除",
     "deleteConfirmDescription": "你确定要删除这个提示词吗？此操作无法撤销。",
     "cancel": "取消",


### PR DESCRIPTION
## Summary
- add create new version button in version history modal linking to latest edit page
- localize create new version label in English and Chinese

## Testing
- `npm test` *(fails: TypeError: Cannot set property url of #<NextRequest> which has only a getter)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b401166410832abbda8b44ffe1e2e4