### PR TITLE
Add published prompts to public page

### DIFF
--- a/app/api/prompts/public/route.js
+++ b/app/api/prompts/public/route.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
 
 const parsePromptsFromFile = (filePath, language) => {
     const markdownContent = fs.readFileSync(filePath, 'utf-8');
@@ -50,19 +51,47 @@ export async function GET(request) {
     const language = searchParams.get('lang') || 'zh';
     const page = parseInt(searchParams.get('page') || '1', 10);
     const pageSize = parseInt(searchParams.get('pageSize') || '20', 10);
-    
+
     try {
-        // 根据语言选择对应的文件
+        let allPrompts = [];
+
+        // 1. 从 markdown 文件读取提示词
         const fileName = language === 'zh' ? 'prompts-cn.md' : 'prompts-en.md';
         const filePath = path.join(process.cwd(), 'public', fileName);
-        
-        // 检查文件是否存在
-        if (!fs.existsSync(filePath)) {
-            return NextResponse.json({ error: 'File not found' }, { status: 404 });
+
+        if (fs.existsSync(filePath)) {
+            allPrompts = parsePromptsFromFile(filePath, language);
         }
-        
-        const allPrompts = parsePromptsFromFile(filePath, language);
-        
+
+        // 2. 从数据库获取已发布的贡献提示词
+        try {
+            const supabase = createClient(
+                process.env.SUPABASE_URL,
+                process.env.SUPABASE_ANON_KEY
+            );
+
+            const { data: publishedContributions, error } = await supabase
+                .from('prompt_contributions')
+                .select('title, role_category, content')
+                .not('published_prompt_id', 'is', null)
+                .eq('status', 'approved');
+
+            if (!error && publishedContributions) {
+                // 将数据库中的贡献转换为与 markdown 相同的格式
+                const contributionPrompts = publishedContributions.map(contrib => ({
+                    category: language === 'zh' ? '社区贡献' : 'Community Contributions',
+                    role: contrib.role_category,
+                    prompt: contrib.content
+                }));
+
+                // 合并两个来源的提示词
+                allPrompts = [...allPrompts, ...contributionPrompts];
+            }
+        } catch (dbError) {
+            console.error('Error fetching published contributions:', dbError);
+            // 即使数据库查询失败，仍然返回 markdown 文件中的提示词
+        }
+
         // 计算分页
         const total = allPrompts.length;
         const totalPages = Math.ceil(total / pageSize);
@@ -70,8 +99,8 @@ export async function GET(request) {
         const startIndex = (currentPage - 1) * pageSize;
         const endIndex = startIndex + pageSize;
         const prompts = allPrompts.slice(startIndex, endIndex);
-        
-        return NextResponse.json({ 
+
+        return NextResponse.json({
             prompts,
             language,
             pagination: {
@@ -84,7 +113,7 @@ export async function GET(request) {
             }
         });
     } catch (error) {
-        console.error('Error reading prompts file:', error);
+        console.error('Error in public prompts API:', error);
         return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
     }
 } 


### PR DESCRIPTION
Add support for displaying prompt contributions with published_prompt_id from the prompt_contributions table on the public prompts page.

Changes:
- Integrate Supabase client to query prompt_contributions table
- Fetch contributions where published_prompt_id is not null and status is approved
- Merge database contributions with existing markdown-based prompts
- Categorize contributions as "社区贡献" (zh) or "Community Contributions" (en)
- Maintain backward compatibility with markdown files