### PR TITLE
Add character limit to public page prompts

### DIFF
--- a/components/prompt/PromptCard.jsx
+++ b/components/prompt/PromptCard.jsx
@@ -173,7 +173,7 @@ function PromptCardComponent({ prompt }) {
         </CardHeader>
         
         <CardContent className="relative z-10 pt-0 pb-6">
-          <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-line group-hover:text-gray-800 dark:group-hover:text-gray-200 transition-colors duration-300">
+          <p className="text-sm text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-line group-hover:text-gray-800 dark:group-hover:text-gray-200 transition-colors duration-300 line-clamp-10">
             {prompt.prompt}
           </p>
         </CardContent>


### PR DESCRIPTION
- Add line-clamp-10 CSS class to prompt content in PromptCard
- Prompts exceeding 10 lines will now display with ellipsis
- Improves readability and layout consistency in public prompts page