### PR TITLE
feat: add Requesty as a playground provider option

### DIFF
--- a/components/playground/providerOptions.json
+++ b/components/playground/providerOptions.json
@@ -230,6 +230,37 @@
     "models": []
   },
   {
+    "value": "requesty",
+    "label": "Requesty",
+    "description": "Requesty OpenAI-compatible gateway (https://requesty.ai).",
+    "baseURL": "https://router.requesty.ai/v1",
+    "endpoints": [
+      {
+        "value": "requesty",
+        "label": "Requesty",
+        "url": "https://router.requesty.ai/v1"
+      }
+    ],
+    "models": [
+      {
+        "value": "openai/gpt-4o-mini",
+        "label": "GPT-4o Mini"
+      },
+      {
+        "value": "anthropic/claude-sonnet-4-5",
+        "label": "Claude Sonnet 4.5"
+      },
+      {
+        "value": "google/gemini-2.5-flash",
+        "label": "Gemini 2.5 Flash"
+      },
+      {
+        "value": "deepseek/deepseek-chat",
+        "label": "DeepSeek Chat"
+      }
+    ]
+  },
+  {
     "value": "custom",
     "label": "Custom Provider",
     "description": "Use any OpenAI-compatible API by configuring the endpoint and key manually.",


### PR DESCRIPTION
## What

Adds [Requesty](https://requesty.ai) to `components/playground/providerOptions.json`, mirroring the existing `openrouter` entry. Requesty is an OpenAI-compatible gateway, so it just needs a `baseURL`, an endpoint, and `provider/model` ids.

The provider list is consumed generically by `PlaygroundSettings.jsx` and `ChatTest.js` (it maps over providers / reads `.models` / `.endpoints`), so no code changes are required.

## Models

I listed only models I verified actually route through Requesty: `openai/gpt-4o-mini`, `anthropic/claude-sonnet-4-5`, `google/gemini-2.5-flash`, `deepseek/deepseek-chat`.

## Tested

- JSON validates.
- eslint on the two consumer components — no errors.
- Confirmed the listed models return valid completions through `https://router.requesty.ai/v1` (OpenAI-compatible, Bearer auth).

## Disclosure

I work at Requesty. This mirrors the existing OpenRouter entry. Happy to adjust the model list, naming, or close if it's not a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Requesty provider with four available models: GPT-4o Mini, Claude Sonnet 4.5, Gemini 2.5 Flash, and DeepSeek Chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->