### PR TITLE
fix team owner role escalation

### DIFF
--- a/__tests__/lib/team-service.roles.test.js
+++ b/__tests__/lib/team-service.roles.test.js
@@ -1,0 +1,27 @@
+import { TeamService, TEAM_ROLES } from '@/lib/team-service.js'
+
+describe('TeamService owner role assignment', () => {
+  it('拒绝通过邀请直接授予 owner', async () => {
+    const service = new TeamService({})
+
+    await expect(service.inviteMember('team-1', 'admin-1', {
+      userId: 'user-1',
+      email: 'user@example.com',
+      role: TEAM_ROLES.OWNER,
+    })).rejects.toMatchObject({
+      status: 400,
+      message: 'Owner role can only be assigned through ownership transfer',
+    })
+  })
+
+  it('拒绝通过成员更新直接授予 owner', async () => {
+    const service = new TeamService({})
+
+    await expect(service.updateMember('team-1', 'user-1', 'admin-1', {
+      role: TEAM_ROLES.OWNER,
+    })).rejects.toMatchObject({
+      status: 400,
+      message: 'Owner role can only be assigned through ownership transfer',
+    })
+  })
+})

--- a/lib/team-service.js
+++ b/lib/team-service.js
@@ -19,6 +19,7 @@ export const TEAM_STATUSES = {
 
 const MANAGER_ROLES = [TEAM_ROLES.OWNER, TEAM_ROLES.ADMIN]
 const ACTIVE_ROLES = [TEAM_ROLES.MEMBER, TEAM_ROLES.ADMIN, TEAM_ROLES.OWNER]
+const ASSIGNABLE_MEMBER_ROLES = [TEAM_ROLES.MEMBER, TEAM_ROLES.ADMIN]
 
 export class TeamService {
   constructor(db) {
@@ -299,6 +300,7 @@ export class TeamService {
   async inviteMember(teamId, actorUserId, { userId, email, role = TEAM_ROLES.MEMBER }) {
     assert(userId, 400, 'Target user is required')
     assert(email, 400, 'Target email is required')
+    assert(ASSIGNABLE_MEMBER_ROLES.includes(role), 400, 'Owner role can only be assigned through ownership transfer')
 
     const team = await this.getTeam(teamId)
     assert(!team.is_personal, 400, 'Cannot invite members to personal teams')
@@ -419,6 +421,10 @@ export class TeamService {
   }
 
   async updateMember(teamId, targetUserId, actorUserId, { role, status }) {
+    if (role) {
+      assert(ASSIGNABLE_MEMBER_ROLES.includes(role), 400, 'Owner role can only be assigned through ownership transfer')
+    }
+
     const actorMembership = await this.assertManager(teamId, actorUserId)
 
     const membership = await this.getTeamMembership(teamId, targetUserId)
@@ -435,9 +441,6 @@ export class TeamService {
     if (role) {
       if (!MANAGER_ROLES.includes(actorMembership.role)) {
         throw new ApiError(403, 'Only admins or owners can change roles')
-      }
-      if (!ACTIVE_ROLES.includes(role)) {
-        throw new ApiError(400, 'Invalid role specified')
       }
       if (membership.role === TEAM_ROLES.OWNER && role !== TEAM_ROLES.OWNER) {
         throw new ApiError(400, 'Use ownership transfer to change owner role')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented direct assignment of the Owner role when inviting new team members.
  * Prevented changing a member’s role to Owner through member updates.
  * Owner role changes must now use the designated ownership transfer process.

* **Tests**
  * Added coverage confirming invalid Owner role assignments are rejected with a clear error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->