### PR TITLE
Add --skip-existing for incremental skills.sh sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ pnpm db:migrate
 pnpm skills:sync
 ```
 
-默认同步前 50 个精选 Skill。仅许可证明确且安全状态可接受的来源会保存完整内容；其余来源只保存索引和出处。使用 `--limit=0` 同步全部精选项，或加 `--all` 切换到完整目录。
+默认同步前 50 个精选 Skill。仅许可证明确且安全状态可接受的来源会保存完整内容；其余来源只保存索引和出处。使用 `--limit=0` 同步全部精选项，或加 `--all` 切换到完整目录。加 `--skip-existing` 可跳过数据库中已有的 Skill，避免重复同步：
+
+```bash
+pnpm skills:sync -- --all --limit=0 --skip-existing
+```
 
 5. **启动开发服务器**
 

--- a/scripts/sync-skills.js
+++ b/scripts/sync-skills.js
@@ -16,6 +16,7 @@ const SYNC_CONCURRENCY = 5
 
 function readArguments(argv) {
   const all = argv.includes('--all')
+  const skipExisting = argv.includes('--skip-existing')
   const limitArg = argv.find((arg) => arg.startsWith('--limit='))
   const startArg = argv.find((arg) => arg.startsWith('--start='))
   const limit = limitArg ? Number.parseInt(limitArg.split('=')[1], 10) : 50
@@ -26,7 +27,7 @@ function readArguments(argv) {
   if (!Number.isInteger(start) || start < 0) {
     throw new Error('--start must be a non-negative integer')
   }
-  return { all, limit, start }
+  return { all, skipExisting, limit, start }
 }
 
 function wait(ms) {
@@ -104,7 +105,7 @@ function safeFiles(files = []) {
 }
 
 async function main() {
-  const { all, limit, start } = readArguments(process.argv.slice(2))
+  const { all, skipExisting, limit, start } = readArguments(process.argv.slice(2))
   const skillsToken = process.env.SKILLS_SH_TOKEN || process.env.VERCEL_OIDC_TOKEN
   if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required')
   if (!skillsToken) throw new Error('SKILLS_SH_TOKEN or VERCEL_OIDC_TOKEN is required')
@@ -133,7 +134,21 @@ async function main() {
 
   try {
     const listedSkills = await listSkills(skillsHeaders, { all, limit })
-    const skills = listedSkills.slice(start)
+    let existingIds = new Set()
+    if (skipExisting) {
+      const rows = await sql`SELECT external_id FROM catalog_skills`
+      existingIds = new Set(rows.map((row) => row.external_id))
+      console.log(`Found ${existingIds.size} skills already in database; skipping them.`)
+    }
+
+    const skills = listedSkills
+      .slice(start)
+      .filter((skill) => !existingIds.has(skill.id))
+    const skipped = listedSkills.slice(start).length - skills.length
+    if (skipExisting) {
+      console.log(`Queued ${skills.length} new skills (${skipped} skipped).`)
+    }
+
     let nextIndex = 0
     let imported = 0
 
@@ -212,7 +227,11 @@ async function main() {
       () => worker()
     ))
 
-    console.log(`Synced ${imported} skills.`)
+    console.log(
+      skipExisting
+        ? `Synced ${imported} new skills (${skipped} already present skipped).`
+        : `Synced ${imported} skills.`
+    )
   } finally {
     await sql.end({ timeout: 5 })
   }

--- a/scripts/sync-skills.js
+++ b/scripts/sync-skills.js
@@ -105,7 +105,8 @@ function safeFiles(files = []) {
 }
 
 async function main() {
-  const { all, skipExisting, limit, start } = readArguments(process.argv.slice(2))
+  const argv = process.argv.slice(2).filter((arg) => arg !== '--')
+  const { all, skipExisting, limit, start } = readArguments(argv)
   const skillsToken = process.env.SKILLS_SH_TOKEN || process.env.VERCEL_OIDC_TOKEN
   if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required')
   if (!skillsToken) throw new Error('SKILLS_SH_TOKEN or VERCEL_OIDC_TOKEN is required')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `--skip-existing` to `pnpm skills:sync` so a full skills.sh catalog sync can continue without re-fetching or rewriting skills already present in `catalog_skills` (matched by `external_id`).

## Usage
```bash
pnpm skills:sync -- --all --limit=0 --skip-existing
```

## Note
Sync execution in this agent environment is blocked: `DATABASE_URL` and `SKILLS_SH_TOKEN` / `VERCEL_OIDC_TOKEN` are not available. Once those are provided (or via `vercel env pull`), the command above can finish the remaining catalog.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fb2b9b4-a042-42c4-a7db-bb56907a6241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fb2b9b4-a042-42c4-a7db-bb56907a6241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

