### PR TITLE
Add skills marketplace with skills.sh-style install methods

### DIFF
--- a/__tests__/components/SkillInstallMethods.test.jsx
+++ b/__tests__/components/SkillInstallMethods.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SkillInstallMethods } from '@/components/skill/SkillInstallMethods'
+
+jest.mock('@/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'en' }),
+}))
+
+jest.mock('@/lib/clipboard', () => ({
+  useClipboard: () => ({
+    copy: jest.fn(),
+    copied: false,
+  }),
+}))
+
+describe('SkillInstallMethods', () => {
+  const skill = {
+    slug: 'find-skills',
+    source: 'vercel-labs/skills',
+    sourceType: 'github',
+    installUrl: 'https://github.com/vercel-labs/skills',
+  }
+
+  it('应该展示与 skills.sh 一致的 Command 安装命令', () => {
+    render(<SkillInstallMethods skill={skill} />)
+
+    expect(screen.getByText(
+      '$ npx skills add https://github.com/vercel-labs/skills --skill find-skills'
+    )).toBeInTheDocument()
+  })
+
+  it('切换到 Prompt 时应展示 skills use 安装提示词', () => {
+    render(<SkillInstallMethods skill={skill} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Prompt' }))
+
+    expect(screen.getByText(
+      /Run `npx skills use "https:\/\/github.com\/vercel-labs\/skills" --skill "find-skills"`/
+    )).toBeInTheDocument()
+  })
+
+  it('缺少安装源时不应渲染', () => {
+    const { container } = render(
+      <SkillInstallMethods
+        skill={{
+          slug: 'lark-approval',
+          source: 'open.feishu.cn',
+          sourceType: 'well-known',
+          installUrl: null,
+        }}
+      />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/__tests__/lib/skills-sync.test.js
+++ b/__tests__/lib/skills-sync.test.js
@@ -1,7 +1,9 @@
 import {
   assessSkillAudits,
+  buildSkillInstallMethods,
   canRedistributeSkill,
   parseSkillFrontmatter,
+  resolveSkillPackageUrl,
 } from '@/lib/skills-sync.js'
 
 describe('skills sync policy', () => {
@@ -34,5 +36,38 @@ description: >
 
     expect(assessment.status).toBe('curated')
     expect(canRedistributeSkill({ licenseSpdx: 'MIT', auditStatus: assessment.status })).toBe(true)
+  })
+
+  it('应该按 skills.sh 格式生成 Command 与 Prompt 安装方式', () => {
+    const methods = buildSkillInstallMethods({
+      slug: 'find-skills',
+      source: 'vercel-labs/skills',
+      sourceType: 'github',
+      installUrl: 'https://github.com/vercel-labs/skills',
+    })
+
+    expect(resolveSkillPackageUrl({
+      source: 'vercel-labs/skills',
+      sourceType: 'github',
+    })).toBe('https://github.com/vercel-labs/skills')
+
+    expect(methods).toEqual({
+      command: 'npx skills add https://github.com/vercel-labs/skills --skill find-skills',
+      prompt: 'Run `npx skills use "https://github.com/vercel-labs/skills" --skill "find-skills"` and follow the generated skill instructions now. Read its complete output, redirecting it to a temporary file first if necessary. Resolve relative paths from the supporting-files directory it provides.',
+    })
+  })
+
+  it('缺少 slug 或安装源时不应生成安装方式', () => {
+    expect(buildSkillInstallMethods({
+      slug: 'lark-approval',
+      source: 'open.feishu.cn',
+      sourceType: 'well-known',
+      installUrl: null,
+    })).toBeNull()
+
+    expect(buildSkillInstallMethods({
+      source: 'vercel-labs/skills',
+      sourceType: 'github',
+    })).toBeNull()
   })
 })

--- a/components/skill/SkillDetail.jsx
+++ b/components/skill/SkillDetail.jsx
@@ -6,6 +6,7 @@ import remarkGfm from 'remark-gfm'
 import { ArrowLeft, ExternalLink, ShieldCheck } from 'lucide-react'
 import { useLanguage } from '@/contexts/LanguageContext'
 import { AddSkillButton } from '@/components/skill/AddSkillButton'
+import { SkillInstallMethods } from '@/components/skill/SkillInstallMethods'
 
 export function SkillDetail({ skill }) {
   const { language } = useLanguage()
@@ -35,20 +36,24 @@ export function SkillDetail({ skill }) {
               {skill.description && <p className="mt-4 max-w-3xl text-base leading-7 text-slate-600">{skill.description}</p>}
             </div>
 
-            {skill.content ? (
-              <article className="prose prose-slate mt-8 max-w-none prose-headings:scroll-mt-20 prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:bg-slate-950">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{skill.content}</ReactMarkdown>
-              </article>
-            ) : (
-              <div className="mt-8 border border-slate-200 bg-white p-8">
-                <h2 className="font-semibold text-slate-950">{zh ? '完整内容未托管' : 'Full content is not hosted'}</h2>
-                <p className="mt-2 text-sm leading-6 text-slate-600">
-                  {zh
-                    ? '该来源的许可证或安全状态尚不满足同步条件，请前往原始来源查看。'
-                    : 'This source does not yet meet the license or security requirements for content sync. View it at the original source.'}
-                </p>
-              </div>
-            )}
+            <div className="mt-8 flex flex-col gap-6">
+              <SkillInstallMethods skill={skill} />
+
+              {skill.content ? (
+                <article className="prose prose-slate max-w-none prose-headings:scroll-mt-20 prose-pre:overflow-x-auto prose-pre:rounded-lg prose-pre:bg-slate-950">
+                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{skill.content}</ReactMarkdown>
+                </article>
+              ) : (
+                <div className="border border-slate-200 bg-white p-8">
+                  <h2 className="font-semibold text-slate-950">{zh ? '完整内容未托管' : 'Full content is not hosted'}</h2>
+                  <p className="mt-2 text-sm leading-6 text-slate-600">
+                    {zh
+                      ? '该来源的许可证或安全状态尚不满足同步条件，请前往原始来源查看。'
+                      : 'This source does not yet meet the license or security requirements for content sync. View it at the original source.'}
+                  </p>
+                </div>
+              )}
+            </div>
 
             {supportingFiles.length > 0 && (
               <section className="mt-12 border-t border-slate-200 pt-8">

--- a/components/skill/SkillInstallMethods.jsx
+++ b/components/skill/SkillInstallMethods.jsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Check, Copy } from 'lucide-react'
+import { useLanguage } from '@/contexts/LanguageContext'
+import { useClipboard } from '@/lib/clipboard'
+import { buildSkillInstallMethods } from '@/lib/skills-sync'
+import { cn } from '@/lib/utils'
+
+export function SkillInstallMethods({ skill }) {
+  const { language } = useLanguage()
+  const zh = language === 'zh'
+  const [mode, setMode] = useState('command')
+  const { copy, copied } = useClipboard(
+    zh ? '已复制到剪贴板' : 'Copied to clipboard',
+    zh ? '复制失败' : 'Copy failed'
+  )
+
+  const methods = useMemo(
+    () => buildSkillInstallMethods({
+      slug: skill.slug,
+      source: skill.source,
+      sourceType: skill.sourceType,
+      installUrl: skill.installUrl,
+    }),
+    [skill.installUrl, skill.slug, skill.source, skill.sourceType]
+  )
+
+  if (!methods) return null
+
+  const value = mode === 'prompt' ? methods.prompt : methods.command
+
+  return (
+    <div className="border border-slate-200 bg-white">
+      <div className="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+        <div>
+          <p className="text-sm font-medium text-slate-950">{zh ? '安装' : 'Installation'}</p>
+          <p className="mt-0.5 text-xs text-slate-500">
+            {zh ? '与 skills.sh 相同的 Command / Prompt 安装方式' : 'Same Command / Prompt install methods as skills.sh'}
+          </p>
+        </div>
+        <div className="inline-flex rounded-lg border border-slate-200 p-0.5" role="group" aria-label={zh ? '安装格式' : 'Install format'}>
+          <button
+            type="button"
+            aria-pressed={mode === 'command'}
+            onClick={() => setMode('command')}
+            className={cn(
+              'rounded-md px-2.5 py-1 text-xs font-medium transition',
+              mode === 'command' ? 'bg-slate-950 text-white' : 'text-slate-600 hover:text-slate-950'
+            )}
+          >
+            Command
+          </button>
+          <button
+            type="button"
+            aria-pressed={mode === 'prompt'}
+            onClick={() => setMode('prompt')}
+            className={cn(
+              'rounded-md px-2.5 py-1 text-xs font-medium transition',
+              mode === 'prompt' ? 'bg-slate-950 text-white' : 'text-slate-600 hover:text-slate-950'
+            )}
+          >
+            Prompt
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => copy(value)}
+        className="group flex w-full items-start gap-3 px-4 py-3 text-left transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-slate-950"
+        aria-label={zh ? '复制安装内容' : 'Copy install content'}
+      >
+        <code className="min-w-0 flex-1 whitespace-pre-wrap break-all font-mono text-xs leading-5 text-slate-800">
+          {mode === 'command' ? `$ ${value}` : value}
+        </code>
+        <span className="mt-0.5 shrink-0 text-slate-400 group-hover:text-slate-700">
+          {copied ? <Check className="h-4 w-4 text-emerald-600" /> : <Copy className="h-4 w-4" />}
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/lib/skills-sync.js
+++ b/lib/skills-sync.js
@@ -76,3 +76,36 @@ export function canRedistributeSkill({ licenseSpdx, auditStatus }) {
     ['curated', 'passed'].includes(auditStatus)
 }
 
+/**
+ * Resolve the package URL used by `npx skills add/use`, matching skills.sh.
+ * Prefers installUrl; falls back to https://github.com/<owner>/<repo> for GitHub sources.
+ */
+export function resolveSkillPackageUrl({ source, sourceType, installUrl } = {}) {
+  if (typeof installUrl === 'string' && installUrl.trim()) {
+    return installUrl.trim().replace(/\/+$/, '')
+  }
+  if (sourceType === 'github' && typeof source === 'string' && /^[^/]+\/[^/]+$/.test(source)) {
+    return `https://github.com/${source}`
+  }
+  return null
+}
+
+/**
+ * Build Command + Prompt install snippets for a skill ID, matching skills.sh.
+ *
+ * Command: npx skills add https://github.com/<owner>/<repo> --skill <slug>
+ * Prompt:  Run `npx skills use "..." --skill "..."` and follow the generated skill instructions...
+ */
+export function buildSkillInstallMethods({ slug, source, sourceType, installUrl } = {}) {
+  if (typeof slug !== 'string' || !slug.trim()) return null
+
+  const packageUrl = resolveSkillPackageUrl({ source, sourceType, installUrl })
+  if (!packageUrl) return null
+
+  const skillId = slug.trim()
+  return {
+    command: `npx skills add ${packageUrl} --skill ${skillId}`,
+    prompt: `Run \`npx skills use "${packageUrl}" --skill "${skillId}"\` and follow the generated skill instructions now. Read its complete output, redirecting it to a temporary file first if necessary. Resolve relative paths from the supporting-files directory it provides.`,
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add a licensed skills catalog sync pipeline and `/skills` browsing pages sourced from skills.sh
- Expose Command/Prompt install snippets matching skills.sh (`npx skills add … --skill <id>`) on skill detail
- Include navigation entry points, security/license gating for hosted content, and related dependency/role hardening fixes on the branch

## Test plan
- [ ] Open `/skills`, search/sort, and open a skill detail page
- [ ] Confirm Installation appears above content with Command/Prompt tabs and copy works
- [ ] Verify install command format: `npx skills add https://github.com/<owner>/<repo> --skill <slug>`
- [ ] Confirm skills without redistributable license show metadata-only / not-hosted content
- [ ] Run `pnpm test __tests__/lib/skills-sync.test.js __tests__/components/SkillInstallMethods.test.jsx`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installation instructions to skill detail pages.
  * Users can switch between command and prompt formats.
  * Added one-click copying for installation instructions with copy confirmation.
  * Installation details are hidden when required skill information is unavailable.

* **Tests**
  * Added coverage for installation commands, prompts, URL handling, and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->